### PR TITLE
refactor: remove duplicate provider lookup in ProviderPanel

### DIFF
--- a/apps/website/src/pages/ProviderPage.tsx
+++ b/apps/website/src/pages/ProviderPage.tsx
@@ -270,23 +270,15 @@ function ProviderPanel() {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
 
-  if (selectedProviderId === null || !config.providers.find((p) => p.id === selectedProviderId)) {
+  const provider = config.providers.find((p) => p.id === selectedProviderId);
+
+  if (!provider) {
     return (
       <div className="flex-1 flex items-center justify-center text-gray-400">
         <div className="text-center">
           <p className="text-sm">{t("panel.unselected.primary")}</p>
           <p className="text-sm">{t("panel.unselected.secondary")}</p>
         </div>
-      </div>
-    );
-  }
-
-  const provider = config.providers.find((p) => p.id === selectedProviderId);
-  if (!provider) {
-    // This should never happen due to earlier check, but handle gracefully
-    return (
-      <div className="flex-1 flex items-center justify-center text-gray-400">
-        <p className="text-sm">{t("panel.unselected.primary")}</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
Remove duplicate provider lookup in ProviderPanel component, consolidating the check into a single find operation.

## Context
The ProviderPanel function had redundant provider lookup logic - it checked for the provider existence twice with two separate `find` calls, resulting in unnecessary array iteration and code duplication.

## Changes
- Combined the two separate `provider.find()` calls into a single lookup
- Simplified the conditional check by removing the redundant `selectedProviderId === null` check (the find result already handles this case)
- Removed the unreachable second fallback branch that had a comment acknowledging it would never execute

## Testing
```bash
# Run type checks and lint
vp check

# Run tests
vp test
```

## Links
- Related issue: Code smell identified during code review