### PR TITLE
refactor: simplify conditional logic in inferInterface

### DIFF
--- a/apps/website/src/api/registry.ts
+++ b/apps/website/src/api/registry.ts
@@ -42,8 +42,8 @@ function inferInterface(endpoints: { anthropic?: string; openai?: string }): {
     return { providerInterface: "openai", baseUrl: openUrl! };
   }
 
-  const baseUrl =
-    anthUrl.includes("/v1") || !openUrl ? anthUrl : openUrl.includes("/v1") ? openUrl : anthUrl;
+  // Use openai URL only when anthropic URL lacks "/v1" but openai URL has it
+  const baseUrl = !anthUrl.includes("/v1") && openUrl?.includes("/v1") ? openUrl : anthUrl;
   return { providerInterface: "anthropic", baseUrl };
 }
 


### PR DESCRIPTION
## Summary
Simplify complex conditional logic in the `inferInterface` function to improve readability and maintainability.

## Context
The original condition used a complex nested ternary expression with multiple conditions that was difficult to understand and maintain. The logic had redundancies that could be simplified.

## Changes
- Simplified the ternary expression from `anthUrl.includes("/v1") || !openUrl ? anthUrl : openUrl.includes("/v1") ? openUrl : anthUrl` to `!anthUrl.includes("/v1") && openUrl?.includes("/v1") ? openUrl : anthUrl`
- Added comment explaining the logic
- Removed redundant conditions while preserving the same behavior

### Key Implementation Details
The simplified logic captures the same behavior:
- Return `openUrl` only when `anthUrl` lacks `/v1` but `openUrl` has it
- Otherwise return `anthUrl`

## Testing
```bash
# Run type checks and lint
vp check

# Run tests
vp test
```

All tests pass including `apps/website/src/api/registry.test.ts`.